### PR TITLE
feat: add theme switcher

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,36 @@
+// Main runtime for AlkindiX site
+// Handles progressive enhancement, theme toggling, and mobile menu
+
+// Remove no-js class when JavaScript is enabled
+document.documentElement.classList.remove('no-js');
+
+// Theme toggle
+themed();
+function themed(){
+  const root = document.documentElement;
+  const toggle = document.querySelector('.theme-toggle');
+  if (!toggle) return;
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light' || stored === 'dark') {
+    root.setAttribute('data-theme', stored);
+    toggle.setAttribute('aria-pressed', stored === 'dark');
+  }
+  toggle.addEventListener('click', () => {
+    const current = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', current);
+    localStorage.setItem('theme', current);
+    toggle.setAttribute('aria-pressed', current === 'dark');
+  });
+}
+
+// Mobile menu toggle
+const menuBtn = document.querySelector('.menu-btn button');
+const menuPanel = document.getElementById('menuPanel');
+if (menuBtn && menuPanel) {
+  menuBtn.addEventListener('click', () => {
+    const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
+    menuBtn.setAttribute('aria-expanded', String(!expanded));
+    menuPanel.hidden = expanded;
+    menuPanel.setAttribute('aria-modal', String(!expanded));
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -70,8 +70,29 @@
   }
 }
 
-html.light { color-scheme: light; }
-html.dark { color-scheme: dark; }
+html[data-theme='dark'] {
+  color-scheme: dark;
+  --bg: #0b0b0c;
+  --panel: #111114;
+  --panel-2: #0f0f12;
+  --text: #f5f7fb;
+  --muted: #b5b9c9;
+  --shadow: 0 24px 60px rgba(0,0,0,.35);
+  --shadow-2: 0 50px 120px rgba(0,0,0,.45);
+  --border: 1px solid rgba(255,255,255,.08);
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+  --bg: #fafafa;
+  --panel: #ffffff;
+  --panel-2: #f6f7fb;
+  --text: #0b0b0c;
+  --muted: #3b4252;
+  --shadow: 0 14px 40px rgba(0,0,0,.08);
+  --shadow-2: 0 40px 90px rgba(0,0,0,.10);
+  --border: 1px solid rgba(0,0,0,.08);
+}
 
 /* --------------------------------------------
    Base / Resets


### PR DESCRIPTION
## Summary
- add progressive enhancement script with theme toggler and mobile menu
- introduce CSS variables for dark and light modes via data-theme attributes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc8a1fe88328ab4c6f5185ff3220